### PR TITLE
TOML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,79 @@
 # UniClOGS Pass Commander
-This software controlls the local functions of a [UniClOGS](https://www.oresat.org/technologies/ground-stations) for sending commands to the [OreSat0](https://www.oresat.org/satellites/oresat0) [CubeSat](https://en.wikipedia.org/wiki/CubeSat).
+This software controls the local functions of a
+[UniClOGS](https://www.oresat.org/technologies/ground-stations) for sending
+commands to the [OreSat0](https://www.oresat.org/satellites/oresat0) and
+[OreSat0.5](https://www.oresat.org/satellites/oresat0-5)
+[CubeSats](https://en.wikipedia.org/wiki/CubeSat).
 
 ## Major functions
-* Tracks satellites using the excellent [ephem](https://rhodesmill.org/pyephem/) module
+* Tracks satellites using the excellent [ephem](https://rhodesmill.org/pyephem/)
+  module
   * Fetches fresh TLEs from [celestrak.org](https://celestrak.org)
-  * Calibrates for atmospheric refraction with local temperature and pressure, fetched via API
+  * Alternatively uses TLEs from a local [Gpredict](https://github.com/csete/gpredict)
+    install
+  * Calibrates for atmospheric refraction with local temperature and pressure,
+    fetched via API from [OpenWeather](https://openweathermap.org/)
 * Adapts tracking information to suit az/el rotator limits
-* Interacts with [Hamlib rotctld](https://github.com/Hamlib/Hamlib/wiki/Documentation) to command the antenna rotator
-* Interacts with [stationd](https://github.com/uniclogs/uniclogs-stationd/tree/python-rewrite) to control amplifiers and station RF path
-* Interacts with the [OreSat GNURadio flowgraph](https://github.com/uniclogs/uniclogs-sdr/tree/maint-3.10/flowgraphs) to manage Doppler shifting and to send command packets
+* Interacts with [Hamlib rotctld](https://github.com/Hamlib/Hamlib/wiki/Documentation)
+  to command the antenna rotator
+* Interacts with [stationd](https://github.com/uniclogs/uniclogs-stationd) to
+  control amplifiers and station RF path
+* Interacts with the [OreSat GNURadio flowgraph](https://github.com/uniclogs/uniclogs-sdr)
+  to manage Doppler shifting and to send command packets
 
 ## Installing
 ```sh
 git clone https://github.com/uniclogs/uniclogs-pass_commander.git
-sudo apt install python3-pip python3-hamlib python3-pydbus python3-requests python3-apscheduler python3-ephem
-python3 uniclogs-pass_commander/
+sudo apt install python3-pip python3-hamlib python3-pydbus
+pip3 install -r uniclogs-pass_commander/requirements.txt
 ```
-You should receive instructions for editing a config file. Go do that now.
 
-When your config is all set up, run with `python3 uniclogs-pass_commander/`
+Running `python3 uniclogs-pass_commander/ --template` will generate a
+template configuration file. You should receive instructions for editing it. Go
+do that now (see below for detailed description).
 
-Testing without rotctld, stationd and a runing radio flowgraph is not presently supported.
+When your config is all set up, run with `python3 uniclogs-pass_commander/`.
+See the `--help` flag for more options.
+
+Testing without rotctld, stationd and a running radio flowgraph is partially
+supported. See the `--mock` flag, especially `-m all`.
+
+## Config file
+It's [TOML](https://toml.io/en/). There are four primary sections, each with
+a set of mandatory configuration keys:
+#### [Main]
+General operation settings.
+* `owmid` (String) - An API key from [OpenWeatherMap API](https://openweathermap.org/api)
+* `edl` (String) - Hex formatted bytes (without 0x) representing an
+  [EDL command](https://oresat-c3-software.readthedocs.io/en/latest/edl.html).
+  Sent periodically during a pass. Consult
+  [oresat-c3-software](https://github.com/oresat/oresat-c3-software) for
+  generating bytes.
+* `txgain` (Integer) - Gain for transmitting. Usually between 0 and 100.
+
+#### [Hosts]
+IP addresses for external components.
+* `radio` (String) - IP address of the flowgraph
+* `station` (String) - IP address of stationd
+* `rotator` (String) - IP address of rotctld
+
+#### [Observer]
+Physical properties of the ground station.
+* `lat` (Float) - Station latitude in decimal notation. For best results use 3 - 4
+  decimal points. See [here](https://xkcd.com/2170/) for more.
+* `lon` (Float) - Station longitude in decimal notation.
+* `alt` (Integer) - Station altitude in meters.
+* `name` (String) - station name or callsign.
+
+#### [TleCache]
+Optional local cache of TLEs. Currently only 3 line TLEs are supported. Format
+is:
+```
+<name>: [
+    "<Satellite name>",
+    "<TLE line 1>",
+    "<TLE line 2>",
+]
+```
+TLE cache entries may be repeated as long as `<name>` is unique. Select which
+entry is active by passing `<name>` to the `--satellite` flag.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ IP addresses for external components.
 
 #### [Observer]
 Physical properties of the ground station.
-* `lat` (Float) - Station latitude in decimal notation. For best results use 3 - 4
+* `lat` (Float or Integer) - Station latitude in decimal notation. For best results use 3 - 4
   decimal points. See [here](https://xkcd.com/2170/) for more.
-* `lon` (Float) - Station longitude in decimal notation.
+* `lon` (Float or Integer) - Station longitude in decimal notation.
 * `alt` (Integer) - Station altitude in meters.
 * `name` (String) - station name or callsign.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ It's [TOML](https://toml.io/en/). There are four primary sections, each with
 a set of mandatory configuration keys:
 #### [Main]
 General operation settings.
-* `owmid` (String) - An API key from [OpenWeatherMap API](https://openweathermap.org/api)
-* `edl` (String) - Hex formatted bytes (without 0x) representing an
+* `satellite` (String, optional) - Default satellite ID, either index into TleCache or NORAD ID.
+* `owmid` (String, optional) - An API key from [OpenWeatherMap API](https://openweathermap.org/api)
+* `edl` (String, optional) - Hex formatted bytes (without 0x) representing an
   [EDL command](https://oresat-c3-software.readthedocs.io/en/latest/edl.html).
   Sent periodically during a pass. Consult
   [oresat-c3-software](https://github.com/oresat/oresat-c3-software) for
@@ -53,9 +54,9 @@ General operation settings.
 
 #### [Hosts]
 IP addresses for external components.
-* `radio` (String) - IP address of the flowgraph
-* `station` (String) - IP address of stationd
-* `rotator` (String) - IP address of rotctld
+* `radio` (String) - IP address or hostname of the flowgraph.
+* `station` (String) - IP address or hostname of stationd.
+* `rotator` (String) - IP address or hostname of rotctld.
 
 #### [Observer]
 Physical properties of the ground station.

--- a/__main__.py
+++ b/__main__.py
@@ -42,6 +42,7 @@ parser.add_argument('-c', '--config', default="~/.config/OreSat/pass_commander.t
 parser.add_argument('--template', action='store_true',
     help='Generate a config template at the path specified by --config')
 parser.add_argument('-e', '--edl-command',
+    type=bytes.fromhex,
     help=dedent('''\
         Optional EDL command to send periodically during a pass
         Must be hex formatted with no 0x prefix'''))

--- a/__main__.py
+++ b/__main__.py
@@ -37,7 +37,7 @@ parser.add_argument('-a', '--action', choices=('run', 'dryrun', 'doppler', 'next
 parser.add_argument('-c', '--config', default="~/.config/OreSat/pass_commander.toml",
     type=Path,
     help=dedent("""\
-        Path to .ini Config file
+        Path to .toml config file. If dir will assume 'pass_commander.toml' in that dir
         Default: '%(default)s'"""))
 parser.add_argument('--template', action='store_true',
     help='Generate a config template at the path specified by --config')

--- a/__main__.py
+++ b/__main__.py
@@ -19,7 +19,9 @@
 #
 
 from argparse import ArgumentParser, RawTextHelpFormatter
+from pathlib import Path
 from textwrap import dedent
+
 from pass_commander.main import main
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
@@ -32,14 +34,13 @@ parser.add_argument('-a', '--action', choices=('run', 'dryrun', 'doppler', 'next
         - nextpass: Sleep until next pass and then quit
         Default: '%(default)s'"""),
     default='run')
-parser.add_argument('-c', '--config', default="~/.config/OreSat/pass_commander.ini",
+parser.add_argument('-c', '--config', default="~/.config/OreSat/pass_commander.toml",
+    type=Path,
     help=dedent("""\
         Path to .ini Config file
         Default: '%(default)s'"""))
-parser.add_argument('--tle-cache', default="~/.config/OreSat/tle_cache.json",
-    help=dedent("""\
-        Path to local JSON TLE cache
-        Default: '%(default)s'"""))
+parser.add_argument('--template', action='store_true',
+    help='Generate a config template at the path specified by --config')
 parser.add_argument('-e', '--edl-command',
     help=dedent('''\
         Optional EDL command to send periodically during a pass
@@ -55,9 +56,12 @@ parser.add_argument('-m', '--mock', action='append', choices=('tx', 'rot', 'con'
 parser.add_argument('-p', '--pass-count', type=int, default=9999,
     help="Maximum number of passes to operate before shutting down. Default: '%(default)s'")
 parser.add_argument('-s', '--satellite',
-    help='can be International Designator, Catalog Number, or Name')
+    help=dedent('''\
+        Can be International Designator, Catalog Number, or Name.
+        If `--mock con` is specified will search local TLE cache and Gpredict cache
+        '''))
 parser.add_argument('-t', '--tx-gain', type=int,
     help='Transmit gain, usually between 0 and 100ish')
 parser.add_argument('-v', '--verbose', action='count',
-    help='Increase verbosity. Not currently implemented')
+    help='Output additional debugging information')
 main(parser.parse_args())

--- a/pass_commander/Tracker.py
+++ b/pass_commander/Tracker.py
@@ -64,6 +64,8 @@ class Tracker:
                 with open(fname) as file:
                     lines = file.readlines()[3:6]
                     tle = [line.rstrip().split("=")[1] for line in lines]
+        elif self.local_only:
+            print("No matching TLE is available locally")
         else:
             tle = requests.get(
                 f"https://celestrak.org/NORAD/elements/gp.php?{self.query}={self.sat_id}"

--- a/pass_commander/Tracker.py
+++ b/pass_commander/Tracker.py
@@ -83,11 +83,10 @@ class Tracker:
         self.sat = ephem.readtle(*self.fetch_tle())
 
     def calibrate(self):
-        if self.local_only:
+        if self.local_only or not self.owmid:
+            # From the ephem docs, temperature defaults to 25 C, pressure defaults to 1010 mBar
             print("not fetching weather for calibration")
             return
-        if not self.owmid:
-            raise ValueError("missing OpenWeatherMap API key")
         r = requests.get(
             f"https://api.openweathermap.org/data/2.5/onecall?lat={deg(self.obs.lat):.3f}&lon="
             f"{deg(self.obs.lon):.3f}&exclude=minutely,hourly,daily,alerts&units=metric&appid={self.owmid}"

--- a/pass_commander/config.py
+++ b/pass_commander/config.py
@@ -1,0 +1,192 @@
+from dataclasses import InitVar, dataclass, field
+from ipaddress import AddressValueError, IPv4Address
+from pathlib import Path
+from typing import Any, Union
+
+import ephem
+import tomlkit
+
+
+class ConfigError(Exception):
+    pass
+
+
+class TleValidationError(ConfigError):
+    def __init__(self, name: str, tle: list[str]):
+        super().__init__(f'TLE for {name}')
+        self.name = name
+        self.tle = tle
+
+
+class IpValidationError(ConfigError):
+    def __init__(self, table: str, key: str, value: Any):
+        super().__init__(f"'{table}.{key}'")
+        self.table = table
+        self.key = key
+        self.value = value
+
+
+class KeyValidationError(ConfigError):
+    def __init__(self, table: str, key: str, expect: str, actual: str):
+        super().__init__(f"'{key}' invalid type {actual}")
+        self.table = table
+        self.key = key
+        self.expect = expect
+        self.actual = actual
+
+
+class TemplateTextError(ConfigError):
+    pass
+
+
+class UnknownKeyError(ConfigError):
+    def __init__(self, keys: list[str]):
+        super().__init__(' '.join(keys))
+        self.keys = keys
+
+
+class MissingKeyError(ConfigError):
+    def __init__(self, table, key):
+        super().__init__(f'{table}.{key}')
+        self.table = table
+        self.key = key
+
+
+class InvalidTomlError(ConfigError):
+    pass
+
+
+class ConfigNotFoundError(ConfigError):
+    pass
+
+
+@dataclass
+class Config:
+    path: InitVar[Path]
+
+    # [Main]
+    owmid: str = '<open weather map API key>'
+    edl: str = '<EDL command to send, hex formatted with no 0x prefix>'
+    txgain: int = 47
+
+    # [Hosts]
+    radio: IPv4Address = IPv4Address('127.0.0.2')
+    station: IPv4Address = IPv4Address('127.0.0.1')
+    rotator: IPv4Address = IPv4Address('127.0.0.1')
+
+    # [Observer]
+    lat: Union[float, str] = '<latitude in decimal notation>'
+    lon: Union[float, str] = '<longitude in decimal notation>'
+    alt: Union[int, str] = '<altitude in meters>'
+    name: str = '<station name or callsign>'
+
+    # ??? Should these be set from cmdline/config?
+    az_cal: int = 0
+    el_cal: int = 0
+
+    # Satellite
+    sat_id: str = "OreSat0"
+    tle_cache: dict[str, list[str]] = field(default_factory=dict)
+
+    # Command line only
+    mock: set[str] = field(default_factory=set)
+    pass_coutn: int = 9999
+
+    def __post_init__(self, path: Path):
+        try:
+            config = tomlkit.parse(path.expanduser().read_text())
+        except tomlkit.exceptions.ParseError as e:
+            raise InvalidTomlError(*e.args) from e
+        except FileNotFoundError as e:
+            raise ConfigNotFoundError from e
+        except IsADirectoryError as e:
+            raise ConfigNotFoundError from e
+
+        # Ensure all template text has been removed
+        for name, table in config.items():
+            if not isinstance(table, tomlkit.items.Table):
+                continue
+            for key, value in table.items():
+                if isinstance(value, str) and value and value[0] == '<':
+                    raise TemplateTextError(f'{name}.{key}')
+
+        def get(cfg: tomlkit.TOMLDocument, table: str, key: str, valtype: type) -> Any:
+            try:
+                entry = cfg[table]
+                if not isinstance(entry, tomlkit.items.Table):
+                    raise UnknownKeyError([table])
+                val = entry.pop(key)
+            except tomlkit.exceptions.NonExistentKey as e:
+                raise MissingKeyError(table, key) from e
+            if not isinstance(val, valtype):
+                raise KeyValidationError(table, key, valtype.__name__, type(val).__name__)
+            return val
+
+        def getip(cfg: tomlkit.TOMLDocument, table: str, key: str, valtype: type) -> IPv4Address:
+            value = get(cfg, table, key, valtype)
+            try:
+                return IPv4Address(value)
+            except AddressValueError as e:
+                raise IpValidationError('Hosts', key, value) from e
+
+        # Mandatory keys
+        self.owmid = get(config, 'Main', 'owmid', str)
+        self.edl = get(config, 'Main', 'edl', str)
+        self.txgain = get(config, 'Main', 'txgain', int)
+
+        self.radio = getip(config, 'Hosts', 'radio', str)
+        self.station = getip(config, 'Hosts', 'station', str)
+        self.rotator = getip(config, 'Hosts', 'rotator', str)
+
+        self.lat = get(config, 'Observer', 'lat', float)
+        self.lon = get(config, 'Observer', 'lon', float)
+        self.alt = get(config, 'Observer', 'alt', int)
+        self.name = get(config, 'Observer', 'name', str)
+
+        # TLE cache is optional
+        self.tle_cache = config.pop('TleCache', {})
+        for key, tle in self.tle_cache.items():
+            try:
+                ephem.readtle(*tle)  # validate TLEs
+            except (TypeError, ValueError) as e:
+                raise TleValidationError(key, tle) from e
+
+        # Ensure there's no extra keys
+        extra = ['Main.' + k for k in config.pop('Main')]
+        extra.extend('Hosts.' + k for k in config.pop('Hosts'))
+        extra.extend('Observer.' + k for k in config.pop('Observer'))
+        extra.extend(k for k in config)
+        if extra:
+            raise UnknownKeyError(extra)
+
+    @classmethod
+    def template(cls, path: Path):
+        config = tomlkit.document()
+        config.add(tomlkit.comment("Be sure to replace all <hint text> including angle brackets!"))
+
+        main = tomlkit.table()
+        main['owmid'] = cls.owmid
+        main['edl'] = cls.edl
+        main['txgain'] = cls.txgain
+
+        hosts = tomlkit.table()
+        hosts['radio'] = str(cls.radio)
+        hosts['station'] = str(cls.station)
+        hosts['rotator'] = str(cls.rotator)
+
+        observer = tomlkit.table()
+        observer['lat'] = cls.lat
+        observer['lon'] = cls.lon
+        observer['alt'] = cls.alt
+        observer['name'] = cls.name
+
+        config['Main'] = main
+        config['Hosts'] = hosts
+        config['Observer'] = observer
+
+        path = path.expanduser()
+        if path.exists():
+            raise FileExistsError
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(tomlkit.dumps(config))

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -23,117 +23,23 @@
 #    - verify doppler
 #    - add a mode for decoding arbitrary sats, then test
 
-import configparser
-import json
+import argparse
 import logging as log
-import operator
-import os
-import sys
-from dataclasses import dataclass, field
-from functools import reduce
+import traceback
 from math import degrees as deg
-from textwrap import dedent
 from time import sleep
-from typing import Union
 
 import ephem
 import pydbus
 from apscheduler.schedulers.background import BackgroundScheduler
 
+from . import config
 from .Navigator import Navigator
 from .Radio import Radio
 from .Rotator import Rotator
 from .Station import Station
 from .Tracker import Tracker
 
-
-@dataclass
-class Config:
-    # Main
-    owmid: str
-    edl: str
-    txgain: int
-
-    # Hosts
-    radio: str
-    station: str
-    rotator: str
-
-    # Observer
-    lat: float
-    lon: float
-    alt: int
-    name: str
-
-    az_cal: int = 0
-    el_cal: int = 0
-
-    # Satellite
-    sat_id: str = "OreSat0"
-    tle_cache: dict[Union[list[str], bool]] = field(default_factory=dict)
-
-
-def load_config_file(path):
-    config_file = os.path.expanduser(path)
-    config = configparser.ConfigParser()
-    if not len(config.read(config_file)):
-        print("Config file seems to be missing. Initializing.")
-        if not os.path.exists(os.path.dirname(config_file)):
-            os.makedirs(os.path.dirname(config_file))
-        with open(config_file, "w") as f:
-            f.write(dedent("""\
-                # Be sure to replace all <hint text> including the angle brackets!
-                [Main]
-                owmid = <open weather map API key>
-                edl = <EDL command to send, hex formatted with no 0x prefix>
-                txgain = 47
-
-                [Hosts]
-                radio = 127.0.0.2
-                station = 127.0.0.1
-                rotator = 127.0.0.1
-
-                [Observer]
-                lat = <latitude in decimal notation>
-                lon = <longitude in decimal notation>
-                alt = <altitude in meters>
-                name = <station name or callsign>
-                """))
-        print(f"Please edit {config_file} before running again.")
-        sys.exit(1)
-
-    if '<' in [v[0] for s in config.keys() for v in config[s].values()]:
-        print(f"Please edit {config_file} and replace everything in <angle brackets>")
-        sys.exit(1)
-
-    # This is just shoehorned in here and ugly. Please fix!
-    def confget(conf, tree):
-        try:
-            return reduce(operator.getitem, tree, conf)
-        except KeyError:
-            print(f"Configuration element missing: {tree[0]}")
-            sys.exit(2)
-
-    return Config(
-        owmid = confget(config, ["Main", "owmid"]),
-        edl = confget(config, ["Main", "edl"]),
-        txgain = int(confget(config, ["Main", "txgain"])),
-        radio = confget(config, ["Hosts", "radio"]),
-        station = confget(config, ["Hosts", "station"]),
-        rotator = confget(config, ["Hosts", "rotator"]),
-        lat = float(confget(config, ["Observer", "lat"])),
-        lon = float(confget(config, ["Observer", "lon"])),
-        alt = int(confget(config, ["Observer", "alt"])),
-        name = confget(config, ["Observer", "name"]),
-    )
-
-
-def load_tle_cache(path):
-    tle_cache_file = os.path.expanduser(path)
-    if os.path.isfile(tle_cache_file):
-        with open(tle_cache_file, "r") as jsonfile:
-            return json.load(jsonfile)
-    return { 'end': True }
 
 class Main:
     def __init__(
@@ -302,57 +208,98 @@ class Main:
             sleep(30)
 
 
-def main(args):
-    conf = load_config_file(args.config)
-    conf.tle_cache = load_tle_cache(args.tle_cache)
-
-    mock = set(args.mock or [])
-    if 'all' in mock:
-        mock = {'tx', 'rot', 'con'}
-
-    # Favor command line values over config file values
-    conf.txgain = args.tx_gain or conf.txgain
-    conf.edl = args.edl_command or conf.edl
-    conf.sat_id = args.satellite or conf.sat_id
-
-    if len(conf.edl) <= 10:
-        print('Not going to TX because no EDL bytes have been defined')
-        mock.add('tx')
-
+def start(action, conf):
     log.basicConfig()
     log.getLogger("apscheduler").setLevel(log.ERROR)
 
     tracker = Tracker(
         (conf.lat, conf.lon, conf.alt),
-        sat_id = conf.sat_id,
-        local_only= 'con' in mock,
-        tle_cache = conf.tle_cache,
-        owmid = conf.owmid,
+        sat_id=conf.sat_id,
+        local_only='con' in conf.mock,
+        tle_cache=conf.tle_cache,
+        owmid=conf.owmid,
     )
     rotator = Rotator(
-        conf.rotator,
-        az_cal = conf.az_cal,
-        el_cal = conf.el_cal,
-        local_only ='con' in mock,
-        no_rot = 'rot' in mock,
+        str(conf.rotator),
+        az_cal=conf.az_cal,
+        el_cal=conf.el_cal,
+        local_only='con' in conf.mock,
+        no_rot='rot' in conf.mock,
     )
-    radio = Radio(conf.radio, local_only='con' in mock)
-    station = Station(conf.station, no_tx='tx' in mock)
+    radio = Radio(str(conf.radio), local_only='con' in conf.mock)
+    station = Station(str(conf.station), no_tx='tx' in conf.mock)
     scheduler = BackgroundScheduler()
 
     commander = Main(tracker, rotator, radio, station, scheduler)
-    if args.action == 'run':
+    if action == 'run':
         commander.autorun(
             tx_gain=conf.txgain,
-            count=args.pass_count,
+            count=conf.pass_count,
             packet=conf.edl,
-            no_tx='tx' in mock,
-            local_only='con' in mock)
-    elif args.action == 'dryrun':
+            no_tx='tx' in conf.mock,
+            local_only='con' in conf.mock,
+        )
+    elif action == 'dryrun':
         commander.dryrun()
-    elif args.action == 'doppler':
+    elif action == 'doppler':
         commander.test_doppler()
-    elif args.action == 'nextpass':
+    elif action == 'nextpass':
         commander.track.sleep_until_next_pass()
     else:
-        print(f"Unknown action: {args.action}")
+        print(f"Unknown action: {action}")
+
+
+def cfgerr(args: argparse.Namespace, msg: str, e: Exception):
+    if args.verbose:
+        traceback.print_exc()
+        print()
+    print(f"In '{args.config}'", msg)
+
+
+def main(args):
+    if args.template:
+        try:
+            config.Config.template(args.config)
+        except FileExistsError as e:
+            cfgerr(args, 'delete existing file before creating template', e)
+        else:
+            print(f"Config template generated at '{args.config}'")
+            print(f"Edit '{args.config}' <template text> before running again")
+        return
+
+    try:
+        conf = config.Config(args.config)
+    except config.ConfigNotFoundError as e:
+        cfgerr(
+            args,
+            f"the file is missing ({type(e.__cause__).__name__}). Initialize using --template",
+            e,
+        )
+    except config.InvalidTomlError as e:
+        cfgerr(args, f"there is invalid toml: {e}\nPossibly an unquoted string?", e)
+    except config.MissingKeyError as e:
+        cfgerr(args, f"required key '{e.table}.{e.key}' is missing", e)
+    except config.TemplateTextError as e:
+        cfgerr(args, f"key '{e}' still has template text. Replace <angle brackets>", e)
+    except config.UnknownKeyError as e:
+        cfgerr(args, f"remove unknown keys: {' '.join(e.keys)}", e)
+    except config.KeyValidationError as e:
+        cfgerr(args, f"key '{e.table}.{e.key}' has invalid type {e.actual}, expected {e.expect}", e)
+    except config.IpValidationError as e:
+        cfgerr(args, f"contents of '{e.table}.{e.key}' is not a valid IP", e)
+    except config.TleValidationError as e:
+        cfgerr(args, f"TLE '{e.name}' is invalid: {e.__cause__}", e)
+    else:
+        conf.mock = set(args.mock or [])
+        if 'all' in conf.mock:
+            conf.mock = {'tx', 'rot', 'con'}
+        # Favor command line values over config file values
+        conf.txgain = args.tx_gain or conf.txgain
+        conf.sat_id = args.satellite or conf.sat_id
+        conf.pass_count = args.pass_count
+        conf.edl = args.edl_command or conf.edl
+        if len(conf.edl) <= 10:
+            print('Not going to TX because no EDL bytes have been defined')
+            conf.mock.add('tx')
+
+        start(args.action, conf)

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -206,7 +206,7 @@ class Main:
             sleep(30)
 
 
-def start(action, conf):
+def start(action: str, conf: config.Config) -> None:
     log.basicConfig()
     log.getLogger("apscheduler").setLevel(log.ERROR)
 
@@ -247,14 +247,14 @@ def start(action, conf):
         print(f"Unknown action: {action}")
 
 
-def cfgerr(args: argparse.Namespace, msg: str):
+def cfgerr(args: argparse.Namespace, msg: str) -> None:
     if args.verbose:
         traceback.print_exc()
         print()
     print(f"In '{args.config}'", msg)
 
 
-def main(args):
+def main(args: argparse.Namespace) -> None:
     if args.template:
         try:
             config.Config.template(args.config)

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -255,6 +255,9 @@ def cfgerr(args: argparse.Namespace, msg: str) -> None:
 
 
 def main(args: argparse.Namespace) -> None:
+    if args.config.is_dir():
+        args.config /= "pass_commander.toml"
+
     if args.template:
         try:
             config.Config.template(args.config)
@@ -295,6 +298,9 @@ def main(args: argparse.Namespace) -> None:
         # Favor command line values over config file values
         conf.txgain = args.tx_gain or conf.txgain
         conf.sat_id = args.satellite or conf.sat_id
+        if not conf.sat_id:
+            print("No satellite specified. Set on command line (see --help) or in config file.")
+            return
         conf.pass_count = args.pass_count
         conf.edl = args.edl_command or conf.edl
         if len(conf.edl) <= 10:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydbus~=0.6.0
 pyephem~=9.99
 Requests~=2.31.0
 ephem~=4.1.4
+tomlkit~=0.9.2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,171 @@
+import unittest
+from ipaddress import IPv4Address
+from pathlib import Path
+from tempfile import NamedTemporaryFile, gettempdir
+
+import tomlkit
+
+from pass_commander import config
+from pass_commander.config import Config
+
+
+class TestConfig(unittest.TestCase):
+    @staticmethod
+    def good_config() -> tomlkit.TOMLDocument:
+        cfg = tomlkit.document()
+
+        main = tomlkit.table()
+        main['owmid'] = "fake-id"
+        main['edl'] = ""
+        main['txgain'] = 47
+
+        hosts = tomlkit.table()
+        hosts['radio'] = "127.0.0.2"
+        hosts['station'] = "127.0.0.1"
+        hosts['rotator'] = "127.0.0.1"
+
+        observer = tomlkit.table()
+        observer['lat'] = 45.0
+        observer['lon'] = -122.0
+        observer['alt'] = 500
+        observer['name'] = 'not-real'
+
+        cfg['Main'] = main
+        cfg['Hosts'] = hosts
+        cfg['Observer'] = observer
+
+        cfg['TleCache'] = {
+            'OreSat0': [
+                "ORESAT0",
+                "1 52017U 22026K   23092.57919752  .00024279  00000+0  10547-2 0  9990",
+                "2 52017  97.5109  94.8899 0023022 355.7525   4.3512 15.22051679 58035",
+            ],
+            '2022-026K': [
+                "ORESAT0",
+                "1 52017U 22026K   23092.57919752  .00024279  00000+0  10547-2 0  9990",
+                "2 52017  97.5109  94.8899 0023022 355.7525   4.3512 15.22051679 58035",
+            ],
+        }
+
+        return cfg
+
+    def test_valid(self):
+        with NamedTemporaryFile(mode='w+') as f:
+            tomlkit.dump(self.good_config(), f)
+            f.flush()
+            conf = Config(Path(f.name))
+        self.assertEqual(conf.owmid, 'fake-id')
+        self.assertEqual(conf.edl, '')
+        self.assertEqual(conf.txgain, 47)
+        self.assertEqual(conf.radio, IPv4Address("127.0.0.2"))
+        self.assertEqual(conf.station, IPv4Address("127.0.0.1"))
+        self.assertEqual(conf.rotator, IPv4Address("127.0.0.1"))
+        self.assertEqual(conf.lat, 45.0)
+        self.assertEqual(conf.lon, -122.0)
+        self.assertEqual(conf.alt, 500)
+        self.assertEqual(conf.name, 'not-real')
+        self.assertEqual(list(conf.tle_cache), ['OreSat0', '2022-026K'])
+
+        # TleCache is optional
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            del conf['TleCache']
+            tomlkit.dump(conf, f)
+            f.flush()
+            Config(Path(f.name))
+
+    def test_missing(self):
+        with self.assertRaises(config.ConfigNotFoundError):
+            Config(Path('missing'))
+
+    def test_invalid(self):
+        with NamedTemporaryFile(mode='w+') as f:
+            f.write('this is not the file you are looking for')
+            f.flush()
+            with self.assertRaises(config.InvalidTomlError):
+                Config(Path(f.name))
+
+    def test_extra_fields(self):
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['Main']['fake'] = "foo"
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.UnknownKeyError):
+                Config(Path(f.name))
+
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['Hosts']['fake'] = "foo"
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.UnknownKeyError):
+                Config(Path(f.name))
+
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['Observer']['fake'] = "foo"
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.UnknownKeyError):
+                Config(Path(f.name))
+
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['Fake'] = tomlkit.table()
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.UnknownKeyError):
+                Config(Path(f.name))
+
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['Fake'] = 3
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.UnknownKeyError):
+                Config(Path(f.name))
+
+    def test_invalid_ip(self):
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['Hosts']['radio'] = 'not an ip'
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.IpValidationError):
+                Config(Path(f.name))
+
+    def test_invalid_tle(self):
+        # Missing lines TypeError
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            del conf['TleCache']['OreSat0'][2]
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.TleValidationError) as e:
+                Config(Path(f.name))
+            self.assertIsInstance(e.exception.__cause__, TypeError)
+
+        # Invalid lines ValueError
+        with NamedTemporaryFile(mode='w+') as f:
+            conf = self.good_config()
+            conf['TleCache']['OreSat0'][1] = "1 52017U 22026K   23092.5791975"
+            tomlkit.dump(conf, f)
+            f.flush()
+            with self.assertRaises(config.TleValidationError) as e:
+                Config(Path(f.name))
+            self.assertIsInstance(e.exception.__cause__, ValueError)
+
+    def test_template(self):
+        temp = Path(gettempdir()) / "faketemplate.toml"
+        try:
+            Config.template(temp)
+            with self.assertRaises(config.TemplateTextError):
+                Config(temp)
+        finally:
+            temp.unlink(missing_ok=True)
+
+    def test_template_exists(self):
+        with NamedTemporaryFile(mode='w+') as f:
+            with self.assertRaises(FileExistsError):
+                Config.template(Path(f.name))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,14 +16,15 @@ class TestConfig(unittest.TestCase):
         cfg = tomlkit.document()
 
         main = tomlkit.table()
+        main['satellite'] = "fake-sat"
         main['owmid'] = "fake-id"
         main['edl'] = ""
         main['txgain'] = 47
 
         hosts = tomlkit.table()
-        hosts['radio'] = "127.0.0.2"
+        hosts['radio'] = "localhost"
         hosts['station'] = "127.0.0.1"
-        hosts['rotator'] = "127.0.0.1"
+        hosts['rotator'] = "127.0.0.2"
 
         observer = tomlkit.table()
         observer['lat'] = 45.509054
@@ -58,18 +59,21 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(conf.owmid, 'fake-id')
         self.assertEqual(conf.edl, b'')
         self.assertEqual(conf.txgain, 47)
-        self.assertEqual(conf.radio, IPv4Address("127.0.0.2"))
+        self.assertEqual(conf.radio, IPv4Address("127.0.0.1"))
         self.assertEqual(conf.station, IPv4Address("127.0.0.1"))
-        self.assertEqual(conf.rotator, IPv4Address("127.0.0.1"))
+        self.assertEqual(conf.rotator, IPv4Address("127.0.0.2"))
         self.assertEqual(conf.lat, radians(45.509054))
         self.assertEqual(conf.lon, radians(-122.681394))
         self.assertEqual(conf.alt, 500)
         self.assertEqual(conf.name, 'not-real')
         self.assertEqual(list(conf.tle_cache), ['OreSat0', '2022-026K'])
 
-        # TleCache is optional
+        # satellite, owmid, edl, TleCache is optional
         with NamedTemporaryFile(mode='w+') as f:
             cfg = self.good_config()
+            del cfg['Main']['satellite']
+            del cfg['Main']['owmid']
+            del cfg['Main']['edl']
             del cfg['TleCache']
             tomlkit.dump(cfg, f)
             f.flush()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,7 +50,7 @@ class TestConfig(unittest.TestCase):
 
         return cfg
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         with NamedTemporaryFile(mode='w+') as f:
             tomlkit.dump(self.good_config(), f)
             f.flush()
@@ -69,25 +69,25 @@ class TestConfig(unittest.TestCase):
 
         # TleCache is optional
         with NamedTemporaryFile(mode='w+') as f:
-            conf = self.good_config()
-            del conf['TleCache']
-            tomlkit.dump(conf, f)
+            cfg = self.good_config()
+            del cfg['TleCache']
+            tomlkit.dump(cfg, f)
             f.flush()
             Config(Path(f.name))
 
-    def test_missing(self):
+    def test_missing(self) -> None:
         with self.assertRaises(config.ConfigNotFoundError):
             Config(Path('missing'))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         with NamedTemporaryFile(mode='w+') as f:
             f.write('this is not the file you are looking for')
             f.flush()
             with self.assertRaises(config.InvalidTomlError):
                 Config(Path(f.name))
 
-    def test_extra_fields(self):
-        cases = [ self.good_config() for _ in range(5) ]
+    def test_extra_fields(self) -> None:
+        cases = [self.good_config() for _ in range(5)]
         cases[0]['Main']['fake'] = "foo"
         cases[1]['Hosts']['fake'] = "foo"
         cases[2]['Observer']['fake'] = "foo"
@@ -101,7 +101,7 @@ class TestConfig(unittest.TestCase):
                 with self.assertRaises(config.UnknownKeyError):
                     Config(Path(f.name))
 
-    def test_invalid_ip(self):
+    def test_invalid_ip(self) -> None:
         with NamedTemporaryFile(mode='w+') as f:
             conf = self.good_config()
             conf['Hosts']['radio'] = 'not an ip'
@@ -110,7 +110,7 @@ class TestConfig(unittest.TestCase):
             with self.assertRaises(config.IpValidationError):
                 Config(Path(f.name))
 
-    def test_integer_lat_lon(self):
+    def test_integer_lat_lon(self) -> None:
         conf = self.good_config()
         conf['Observer']['lat'] = 45
         conf['Observer']['lat'] = -122
@@ -121,8 +121,8 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(out.lat, radians(conf['Observer']['lat']))
             self.assertEqual(out.lon, radians(conf['Observer']['lon']))
 
-    def test_invalid_lat_lon(self):
-        cases = [ self.good_config() for _ in range(4) ]
+    def test_invalid_lat_lon(self) -> None:
+        cases = [self.good_config() for _ in range(4)]
         cases[0]['Observer']['lat'] = 270.4
         cases[1]['Observer']['lat'] = -270.9
         cases[2]['Observer']['lon'] = 270.7
@@ -134,7 +134,7 @@ class TestConfig(unittest.TestCase):
                 with self.assertRaises(config.AngleValidationError):
                     Config(Path(f.name))
 
-    def test_invalid_tle(self):
+    def test_invalid_tle(self) -> None:
         # Missing lines TypeError
         with NamedTemporaryFile(mode='w+') as f:
             conf = self.good_config()
@@ -155,7 +155,7 @@ class TestConfig(unittest.TestCase):
                 Config(Path(f.name))
             self.assertIsInstance(e.exception.__cause__, ValueError)
 
-    def test_edl(self):
+    def test_edl(self) -> None:
         # Valid full edl command
         with NamedTemporaryFile(mode='w+') as f:
             conf = self.good_config()
@@ -185,7 +185,7 @@ class TestConfig(unittest.TestCase):
             with self.assertRaises(config.KeyValidationError):
                 Config(Path(f.name))
 
-    def test_template(self):
+    def test_template(self) -> None:
         temp = Path(gettempdir()) / "faketemplate.toml"
         try:
             Config.template(temp)
@@ -194,7 +194,7 @@ class TestConfig(unittest.TestCase):
         finally:
             temp.unlink(missing_ok=True)
 
-    def test_template_exists(self):
+    def test_template_exists(self) -> None:
         with NamedTemporaryFile(mode='w+') as f:
             with self.assertRaises(FileExistsError):
                 Config.template(Path(f.name))


### PR DESCRIPTION
[TOML](https://toml.io/en/) is a well specified and widely supported configuration language similar to ini but with modern conveniences. Among other things it supports nested structures allowing the local TLE cache to be merged in. This also no longer automatically generates a config template, instead prompting the user to make one with the `--template` flag.

Note that when upgrading in place pass_commander installs, `pip install -r requirements.txt` will be needed to be rerun, pass_commander.ini should be renamed to pass_commander.toml, and in the config double quotes must be added to all values interpreted as a string. The TLE cache should also be merged in (see the updated README).

Additionally this tries to move config value validation forwards in time, ideally to the point where we read in the config, so that invalid settings are alerted as soon as possible and especially not when a pass starts.

Some questions still remain though:
- `az_cal` and `el_cal` are rotator calibration offsets which are configurable in code. Do we want them to be config file fields? Optional or mandatory?
- Which fields should be optional? Currently it mirrors the old behavior of all fields mandatory except for the new TLE cache which is optional. But things like `owmid` or `edl` could reasonably be optional instead of empty string to disable. Are there other fields that could be optional?

For reference this is the TOML config I've been testing with. Note the quoting:
```TOML
[Main]
owmid = ""
edl = ""
txgain = 47

[Hosts]
radio = "127.0.0.2"
station = "127.0.0.1"
rotator = "127.0.0.1"

[Observer]
lat = 45.509054
lon = -122.681394
alt = 50
name = "Ground"

[TleCache]
OreSat0 = [
    "ORESAT0",
    "1 52017U 22026K   23092.57919752  .00024279  00000+0  10547-2 0  9990",
    "2 52017  97.5109  94.8899 0023022 355.7525   4.3512 15.22051679 58035",
]
"OreSat0r" = [
    "ORESAT0",
    "1 52017U 22026K   24237.61773939  .00250196  00000+0  18531-2 0  9992",
    "2 52017  97.4861 255.7395 0002474 307.8296  52.2743 15.72168729136382",
]
2022-026K = [
    "ORESAT0",
    "1 52017U 22026K   23092.57919752  .00024279  00000+0  10547-2 0  9990",
    "2 52017  97.5109  94.8899 0023022 355.7525   4.3512 15.22051679 58035",
]
```
This PR also somewhat addresses #3 