### PR TITLE
Correct doppler corrections

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -28,7 +28,7 @@ parser.add_argument('-a', '--action', choices=('run', 'dryrun', 'doppler', 'next
         Which action to have Pass Commander take
         - run: Normal operation
         - dryrun: Simulate the next pass immediately
-        - doppler: Simulate doppler shift during a pass
+        - doppler: Show present RX/TX frequencies
         - nextpass: Sleep until next pass and then quit
         Default: '%(default)s'"""),
     default='run')

--- a/pass_commander/Radio.py
+++ b/pass_commander/Radio.py
@@ -25,6 +25,7 @@ from threading import Lock
 from xmlrpc.client import ServerProxy
 from time import sleep
 
+from .Tracker import Tracker
 
 class Radio:
     def __init__(self, host, xml_port=10080, edl_port=10025, local_only=False):
@@ -52,5 +53,18 @@ class Radio:
             ret = xo.__getattr__(func)(*args)
         return ret
 
+    def set_rx_frequency(self, track: Tracker) -> None:
+        # RX on the ground frequeny. track.doppler is the satellite relative velocity scaled, so it
+        # starts negative and goes positive, so the frequency starts high and goes low
+        self.command("set_gpredict_rx_frequency", (1 - track.doppler) * self.rxfreq)
+
+    def set_tx_frequency(self, track: Tracker) -> None:
+        # TX is the opposite of RX, starts low, goes high
+        self.command("set_gpredict_tx_frequency", (1 + track.doppler) * self.txfreq)
+
+
     def edl(self, packet):
         self.s.sendto(packet, self.edl_addr)
+
+    def close(self):
+        self.s.close()

--- a/pass_commander/Radio.py
+++ b/pass_commander/Radio.py
@@ -53,15 +53,20 @@ class Radio:
             ret = xo.__getattr__(func)(*args)
         return ret
 
-    def set_rx_frequency(self, track: Tracker) -> None:
+    def rx_frequency(self, track: Tracker) -> float:
         # RX on the ground frequeny. track.doppler is the satellite relative velocity scaled, so it
         # starts negative and goes positive, so the frequency starts high and goes low
-        self.command("set_gpredict_rx_frequency", (1 - track.doppler) * self.rxfreq)
+        return (1 - track.doppler) * self.rxfreq
+
+    def set_rx_frequency(self, track: Tracker) -> None:
+        self.command("set_gpredict_rx_frequency", self.rx_frequency(track))
+
+    def tx_frequency(self, track: Tracker) -> float:
+        # TX is the opposite of RX, starts low, goes high
+        return (1 + track.doppler) * self.txfreq
 
     def set_tx_frequency(self, track: Tracker) -> None:
-        # TX is the opposite of RX, starts low, goes high
-        self.command("set_gpredict_tx_frequency", (1 + track.doppler) * self.txfreq)
-
+        self.command("set_gpredict_tx_frequency", self.tx_frequency(track))
 
     def edl(self, packet):
         self.s.sendto(packet, self.edl_addr)

--- a/pass_commander/Tracker.py
+++ b/pass_commander/Tracker.py
@@ -27,6 +27,7 @@ from datetime import datetime, timedelta
 from math import degrees as deg
 from multiprocessing import Manager
 from time import sleep
+from typing import Optional
 import ephem
 
 
@@ -94,10 +95,10 @@ class Tracker:
         self.obs.temp = c["temp"]
         self.obs.pressure = c["pressure"]
 
-    def freshen(self):
+    def freshen(self, date: Optional[ephem.Date]=None):
         """perform a new calculation of satellite relative to observer"""
         # ephem.now() does not provide subsecond precision, use ephem.Date() instead:
-        self.obs.date = ephem.Date(datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"))
+        self.obs.date = date or ephem.Date(datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"))
         # self.obs.date = ephem.Date(self.obs.date + ephem.second)   # look-ahead
         self.sat.compute(self.obs)
         return self
@@ -107,9 +108,14 @@ class Tracker:
         self.share["target_el"] = deg(self.sat.alt)
         return (self.sat.az, self.sat.alt)
 
-    def doppler(self, freq=436500000):
-        """returns RX doppler shift in hertz for the provided frequency"""
-        return -self.sat.range_velocity / ephem.c * freq
+    @property
+    def doppler(self):
+        """returns the unitless value to scale frequencies for doppler shift
+
+        Note that as the satellite is approaching the observer the value is negative, and as it's
+        moving away the value is positive.
+        """
+        return self.sat.range_velocity / ephem.c
 
     def az_at_time(self, time):
         self.obs.date = time

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -162,10 +162,7 @@ class Main:
         print("System clock is synchronized.")
 
     def edl(self, packet):
-        self.rad.command(
-            "set_gpredict_tx_frequency",
-            self.rad.txfreq - self.track.freshen().doppler(self.rad.txfreq),
-        )
+        self.rad.set_tx_frequency(self.track.freshen())
         self.rad.edl(packet)
 
     def autorun(self, tx_gain, count=9999, packet=None, no_tx=False, local_only=False):
@@ -260,10 +257,7 @@ class Main:
     def update_rotator(self):
         azel = self.nav.azel(self.track.freshen().azel())
         self.rot.go(*tuple(deg(x) for x in azel))
-        self.rad.command(
-            "set_gpredict_rx_frequency",
-            self.track.doppler(self.rad.rxfreq) - self.rad.rxfreq,
-        )
+        self.rad.set_rx_frequency(self.track)
 
     # Testing stuff goes below here
 

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -287,7 +287,9 @@ class Main:
 
     def test_doppler(self):
         while True:
-            print(self.track.freshen().doppler())
+            rxfinal = self.rad.rx_frequency(self.track.freshen())
+            txfinal = self.rad.tx_frequency(self.track)
+            print(f"RX = {rxfinal:.3f}  TX = {txfinal:.3f}")
             sleep(0.1)
 
     def test_morse(self):

--- a/tests/mock_flowgraph.py
+++ b/tests/mock_flowgraph.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from xmlrpc.server import SimpleXMLRPCServer
+
+# TODO: configure address
+
+
+class Flowgraph:
+    def __init__(self):
+        self.morse_bump = 0
+
+        self.server = SimpleXMLRPCServer(('127.0.0.2', 10080), allow_none=True, logRequests=False)
+        self.server.register_instance(self)
+
+    def start(self):
+        self.server.serve_forever()
+
+    def stop(self):
+        self.server.shutdown()
+
+    def get_tx_center_frequency(self):
+        return 1_265_000_000
+
+    def get_rx_target_frequency(self):
+        return 436_500_000
+
+    def set_gpredict_tx_frequency(self, value):
+        print("TX Freq", value)
+
+    def set_gpredict_rx_frequency(self, value):
+        print("RX Freq", value)
+
+    def set_morse_bump(self, val):
+        self.morse_bump = val
+
+    def get_morse_bump(self):
+        return self.morse_bump
+
+
+if __name__ == '__main__':
+    Flowgraph()

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -8,11 +8,14 @@ from pass_commander.Radio import Radio
 from pass_commander.Tracker import Tracker
 from .mock_flowgraph import Flowgraph
 
+
 class test_radio(unittest.TestCase):
     def test_doppler(self):
         flowgraph = Flowgraph()
         rx = []
+        tx = []
         flowgraph.server.register_function(lambda x: rx.append(x), "set_gpredict_rx_frequency")
+        flowgraph.server.register_function(lambda x: tx.append(x), "set_gpredict_tx_frequency")
         fgthread = Thread(target=flowgraph.start)
         fgthread.start()
 
@@ -23,19 +26,24 @@ class test_radio(unittest.TestCase):
                 "2 52017  97.4861 255.7395 0002474 307.8296  52.2743 15.72168729136382",
             ]
         })
-        date = ephem.Date(45541.170401489704) # start of a pass, determined through divination
+        date = ephem.Date(45541.170401489704)  # start of a pass, determined through divination
         track.freshen(date)
         radio = Radio("127.0.0.2")
 
-        for t in range(10*60): # passes are about 10 minutes
+        for t in range(10 * 60):  # passes are about 10 minutes
             track.freshen(ephem.Date(date + t * ephem.second))
             radio.set_rx_frequency(track)
+            radio.set_tx_frequency(track)
 
         flowgraph.stop()
         fgthread.join()
         radio.close()
 
-        # doppler moves from high frequency to low frequency
-        self.assertGreater(rx[0], rx[-1])
+        # RX doppler moves from high frequency to low frequency, passing over the center frequency
+        self.assertTrue(rx[0] > radio.rxfreq > rx[-1])
         # monotonically decreasing
         self.assertTrue(all(x > y for x, y in pairwise(rx)))
+
+        # TX does the opposite, monotonically low -> high, again passing the center frequency
+        self.assertTrue(tx[0] < radio.txfreq < tx[-1])
+        self.assertTrue(all(x < y for x, y in pairwise(tx)))

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,0 +1,41 @@
+import unittest
+from itertools import pairwise
+from threading import Thread
+
+import ephem
+
+from pass_commander.Radio import Radio
+from pass_commander.Tracker import Tracker
+from .mock_flowgraph import Flowgraph
+
+class test_radio(unittest.TestCase):
+    def test_doppler(self):
+        flowgraph = Flowgraph()
+        rx = []
+        flowgraph.server.register_function(lambda x: rx.append(x), "set_gpredict_rx_frequency")
+        fgthread = Thread(target=flowgraph.start)
+        fgthread.start()
+
+        track = Tracker(("45", "-122", 50), local_only=True, tle_cache = {
+            "OreSat0": [
+                "ORESAT0",
+                "1 52017U 22026K   24237.61773939  .00250196  00000+0  18531-2 0  9992",
+                "2 52017  97.4861 255.7395 0002474 307.8296  52.2743 15.72168729136382",
+            ]
+        })
+        date = ephem.Date(45541.170401489704) # start of a pass, determined through divination
+        track.freshen(date)
+        radio = Radio("127.0.0.2")
+
+        for t in range(10*60): # passes are about 10 minutes
+            track.freshen(ephem.Date(date + t * ephem.second))
+            radio.set_rx_frequency(track)
+
+        flowgraph.stop()
+        fgthread.join()
+        radio.close()
+
+        # doppler moves from high frequency to low frequency
+        self.assertGreater(rx[0], rx[-1])
+        # monotonically decreasing
+        self.assertTrue(all(x > y for x, y in pairwise(rx)))


### PR DESCRIPTION
This fixes the RX doppler correction, and some effort was put in to ensure the new values are correct:
- Calculation centralized in `Radio`, easy to visually inspect
- `--action doppler` prints the values in a way that can be compared by hand to Gpredict output
- unit tests checking behavior during a specific pass
- a stub xmlrpc server to support tests, and also for future enhanced `local-only` modes.