### PR TITLE
Project name not set correctly in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pass-commander"
+name = "uniclogs-pass-commander"
 description = "The controller for local UniClOGS functions."
 requires-python = ">=3.11"
 license = {text = "GPL-3.0"}


### PR DESCRIPTION
When attempting to cut a release and let the pypi automation run, it failed with the following error:

```
Uploading pass_commander-1.0.0-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Non-user identities cannot create new projects. This was probably      
         caused by successfully using a pending publisher but specifying the    
         project name incorrectly (either in the publisher or in your project's 
         metadata). Please ensure that both match. See:                         
         https://docs.pypi.org/trusted-publishers/troubleshooting/ 
```

Unless we've missed it elsewhere, I think this is the only correction needed.