### PR TITLE
Fix malformed template, cache CelesTrak TLEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ Running `pass-commander --template` will generate a
 template configuration file. You should receive instructions for editing it. Go
 do that now (see below for detailed description).
 
-When your config is all set up, run with `pass-commander`. See the
-`--help` flag for more options. For example `pass-commander -s 60525
--m all -a dryrun`.
+When your config is all set up, run with `pass-commander`. See the `--help` flag
+for more options. Initially you'll not have any saved TLEs so either find one
+for your satellite of interest and add it to `TleCache` in `pass_commander.toml`
+or run without the `--mock tle` flag to download one locally:
+```sh
+pass-commander --satellite 60525 --action dryrun -m tx -m con -m rot
+```
+After that the `--mock all` flag can be used for brevity:
+```sh
+pass-commander --satellite 60525 --action dryrun --mock all
+```
 
 Testing without rotctld, stationd and a running radio flowgraph is partially
 supported. See the `--mock` flag, especially `-m all`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UniClOGS Pass Commander
 This software controls the local functions of a
-[UniClOGS](https://www.oresat.org/technologies/ground-stations) for sending
-commands to the [OreSat0](https://www.oresat.org/satellites/oresat0) and
-[OreSat0.5](https://www.oresat.org/satellites/oresat0-5)
-[CubeSats](https://en.wikipedia.org/wiki/CubeSat).
+[UniClOGS](https://www.oresat.org/technologies/ground-stations) ground station
+for sending commands to [CubeSats](https://en.wikipedia.org/wiki/CubeSat), as
+used with the [OreSat0](https://www.oresat.org/satellites/oresat0)
+and [OreSat0.5](https://www.oresat.org/satellites/oresat0-5) missions.
 
 ## Major functions
 * Tracks satellites using the excellent [Skyfield](https://rhodesmill.org/skyfield/)
@@ -22,6 +22,8 @@ commands to the [OreSat0](https://www.oresat.org/satellites/oresat0) and
   to manage Doppler shifting and to send command packets
 
 ## Installing
+Requires Linux with Python 3.11 or greater.
+
 ```sh
 git clone https://github.com/uniclogs/uniclogs-pass-commander.git
 sudo apt install python3-pip

--- a/pass_commander/commander.py
+++ b/pass_commander/commander.py
@@ -339,7 +339,10 @@ class Commander:
 
         while True:
             sat = Satellite(
-                self.conf.sat_id, tle_cache=self.conf.tle_cache, local_only='con' in self.conf.mock
+                self.conf.sat_id,
+                self.conf.dir,
+                tle_cache=self.conf.tle_cache,
+                local_only='tle' in self.conf.mock,
             )
             np = self.track.next_pass(sat, min_el=self.conf.min_el)
             if np is None:
@@ -418,7 +421,10 @@ class Commander:
 
     def dryrun(self) -> None:
         sat = Satellite(
-            self.conf.sat_id, tle_cache=self.conf.tle_cache, local_only='con' in self.conf.mock
+            self.conf.sat_id,
+            self.conf.dir,
+            tle_cache=self.conf.tle_cache,
+            local_only='tle' in self.conf.mock,
         )
         np = self.track.next_pass(sat, min_el=Angle(degrees=80), lookahead=timedelta(days=30))
         if np is None:

--- a/pass_commander/config.py
+++ b/pass_commander/config.py
@@ -169,6 +169,8 @@ class Config:
     # Command line only
     mock: set[str] = field(default_factory=set)
     pass_count: int = 9999
+    # FIXME: use XDG_CONFIG_HOME
+    dir: PosixPath = PosixPath('~/.config/OreSat').expanduser()  # noqa: RUF009
 
     def __post_init__(self, path: Path) -> None:
         '''Load a config from a given file.
@@ -188,8 +190,11 @@ class Config:
         path
             Path to the config file, usually pass_commander.toml
         '''
+        path = path.expanduser()
+        self.dir = PosixPath(path.parent)
+
         try:
-            config = tomlkit.parse(path.expanduser().read_text())
+            config = tomlkit.parse(path.read_text())
         except tomlkit.exceptions.ParseError as e:
             raise InvalidTomlError(*e.args) from e
         except FileNotFoundError as e:
@@ -259,7 +264,7 @@ class Config:
 
         hosts = tomlkit.table()
         hosts['radio'] = str(cls.flowgraph[0])
-        hosts['station'] = str(cls.station)
+        hosts['station'] = str(cls.station[0])
         hosts['rotator'] = str(cls.rotator)
 
         observer = tomlkit.table()

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -30,7 +30,7 @@ def handle_args() -> Namespace:  # noqa: D103
     parser.add_argument(
         "-c",
         "--config",
-        default="~/.config/OreSat/pass_commander.toml",
+        default=config.Config.dir / "pass_commander.toml",
         type=Path,
         help=dedent(
             """\
@@ -54,13 +54,14 @@ def handle_args() -> Namespace:  # noqa: D103
         "-m",
         "--mock",
         action="append",
-        choices=("tx", "rot", "con", "all"),
+        choices=("tx", "rot", "con", "tle", "all"),
         help=dedent(
             """\
             Use a simulated (mocked) external dependency, not the real thing
             - tx: No PTT or EDL bytes sent to flowgraph
             - rot: No actual movement commanded for the rotator
-            - con: Don't use network services - TLEs, weather, rot2prog, stationd
+            - con: Don't use network services - weather, rot2prog, stationd
+            - tle: Only use locally saved TLEs, don't fetch from the internet (CelesTrak)
             - all: All of the above
             Can be issued multiple times, e.g. '-m tx -m rot' will disable tx and rotator"""
         ),
@@ -152,7 +153,7 @@ def main() -> None:  # noqa: D103 C901 PLR0912 PLR0915
     else:
         conf.mock = set(args.mock or [])
         if 'all' in conf.mock:
-            conf.mock = {'tx', 'rot', 'con'}
+            conf.mock = {'tx', 'rot', 'con', 'tle'}
         # Favor command line values over config file values
         conf.txgain = args.tx_gain or conf.txgain
         conf.sat_id = args.satellite or conf.sat_id

--- a/pass_commander/satellite.py
+++ b/pass_commander/satellite.py
@@ -72,6 +72,9 @@ class Satellite(EarthSatellite):  # type: ignore[misc]
         if tle is None and filename.exists():
             logger.info("using cached TLE from %s", filename)
             lines = filename.read_text().splitlines()
+            # Not documented but CelesTrak currently returns this string if the previous query
+            # didn't match an object it knows about. We have to cache it anyway to respect their
+            # policy.
             if lines[0] == "No GP data found":
                 logger.info("No results for %s at celestrak", sat_id)
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,6 @@ tles = [
 
 
 @pytest.fixture(params=tles)
-def sat(request) -> Satellite:  # noqa: ANN001
+def sat(request, tmp_path: Path) -> Satellite:  # noqa: ANN001
     name = request.param[0]
-    return Satellite(name, tle_cache={name: request.param}, local_only=True)
+    return Satellite(name, tmp_path, tle_cache={name: request.param}, local_only=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,9 +165,22 @@ class TestConfig:
             Config(path)
 
     def test_template(self, tmp_path: Path) -> None:
-        Config.template(tmp_path / "faketemplate.toml")
+        path = tmp_path / "faketemplate.toml"
+        Config.template(path)
+
+        # Trying to load the template should fail because template text hasn't been removed
         with pytest.raises(config.TemplateTextError):
-            Config(tmp_path / "faketemplate.toml")
+            Config(path)
+
+        # But if we remove the template text
+        with path.open('r') as f:
+            contents = f.read()
+        contents = contents.replace('<', '')
+        contents = contents.replace('>', '')
+        with path.open('w') as f:
+            f.write(contents)
+        # then it should load
+        Config(path)
 
     def test_template_exists(self, tmp_path: Path) -> None:
         conf = tmp_path / "config.toml"


### PR DESCRIPTION
This was supposed to be two commits but a wayward --amend means these get squashed:

- Make sure that we can load the template config once all the template text has been replaced. The Hosts.station field default wasn't updated in the template when the representation changed in Config so the template was generating invalid values. This adds a test to try and prevent that in the future and fixes the direct issue.

- Implement TLE caching for CelesTrak. CelesTrak asks that we access their API no more than once every two hours. During normal operation our access is dictated by when a pass happens which isn't really more than once or twice a day, but during testing or experimenting we could fetch a TLE on every start up. This also affects new users who wouldn't initially have a TLE or know how to get one. The method employed here mirrors how skyfield does it but I chose not to use their api directly for easier testing. In the future after the Pydantic change this should probably be redone, possibly to append to the pass_commander.toml TleCache.